### PR TITLE
p0: add key.properties gitignore + example template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Release signing config — must never be committed.
+/android/key.properties

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,9 @@
+# Copy to android/key.properties and fill in the values.
+# android/key.properties is .gitignored — never commit real credentials.
+#
+# storeFile is relative to android/app/, so the keystore already in the
+# repo root's KEYSTORE/ directory is reached via ../../KEYSTORE/...
+storePassword={{STORE_PASSWORD}}
+keyPassword={{KEY_PASSWORD}}
+keyAlias={{ALIAS}}
+storeFile=../../KEYSTORE/aultra_paints_keystore.jks


### PR DESCRIPTION
## Summary

Close the signing-credentials gap left by PR #32 (which wired `android/app/build.gradle` to read from `key.properties` but did not add a `.gitignore` entry for that file, nor commit an example template).

- **`.gitignore`**: add `/android/key.properties` so real credentials cannot be committed
- **`android/key.properties.example`**: new committed template with placeholders (`{{STORE_PASSWORD}}`, `{{KEY_PASSWORD}}`, `{{ALIAS}}`, `storeFile=../../KEYSTORE/aultra_paints_keystore.jks`)

Does not touch `android/app/build.gradle` — the Gradle wiring is already correct.

## Verification

- `git check-ignore -v android/key.properties` confirms the ignore rule fires
- `ls android/key.properties.example` confirms the template is present

## Test plan

- [ ] Copy `android/key.properties.example` → `android/key.properties`, fill in real secrets, run `flutter build appbundle --release`
- [ ] Confirm the produced `.aab` is signed with the release keystore (not debug)
- [ ] `git status` does not show `android/key.properties` after creating it locally