### PR TITLE
p0: wire flutter_secure_storage for auth bearer tokens

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../services/secure_token_store.dart';
 
 class AuthProvider extends ChangeNotifier {
   String? _accessToken;
@@ -24,12 +25,13 @@ class AuthProvider extends ChangeNotifier {
   String? get userParentDealerName => _userParentDealerName;
   bool get isInitialized => _isInitialized;
 
-  // Initialize auth state from storage
+  // Initialize auth state from storage. Token lives in secure storage now;
+  // non-sensitive profile fields stay in SharedPreferences.
   Future<void> initialize() async {
     if (_isInitialized) return;
 
     final prefs = await SharedPreferences.getInstance();
-    _accessToken = prefs.getString('accessToken');
+    _accessToken = await SecureTokenStore.instance.readToken();
     _userId = prefs.getString('USER_ID');
     _userFullName = prefs.getString('USER_FULL_NAME');
     _userMobileNumber = prefs.getString('USER_MOBILE_NUMBER');
@@ -56,7 +58,9 @@ class AuthProvider extends ChangeNotifier {
   }) async {
     final prefs = await SharedPreferences.getInstance();
 
-    await prefs.setString('accessToken', accessToken);
+    // Token goes to secure storage; profile fields to plain prefs.
+    await SecureTokenStore.instance.writeToken(accessToken);
+    await prefs.remove('accessToken'); // clear any legacy plaintext copy
     await prefs.setString('USER_ID', userId);
     await prefs.setString('USER_FULL_NAME', userFullName);
     await prefs.setString('USER_MOBILE_NUMBER', userMobileNumber);
@@ -84,6 +88,7 @@ class AuthProvider extends ChangeNotifier {
   Future<void> clearAuth() async {
     final prefs = await SharedPreferences.getInstance();
 
+    await SecureTokenStore.instance.clear();
     await prefs.remove('accessToken');
     await prefs.remove('USER_ID');
     await prefs.remove('USER_FULL_NAME');

--- a/lib/services/secure_token_store.dart
+++ b/lib/services/secure_token_store.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// SecureTokenStore backs the auth bearer token and other credential-grade
+/// values with platform secure storage (Keychain on iOS, Keystore on Android).
+///
+/// The legacy build persisted these in SharedPreferences as plain strings,
+/// which is unacceptable for a payments app. On first call, any legacy
+/// token is migrated into secure storage and then deleted from prefs.
+class SecureTokenStore {
+  SecureTokenStore._();
+  static final SecureTokenStore instance = SecureTokenStore._();
+
+  static const _tokenKey = 'authToken';
+  static const _userIdKey = 'userId';
+  static const _accountTypeKey = 'accountType';
+  static const _mobileKey = 'mobile';
+
+  final _secure = const FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  );
+
+  Future<void> writeToken(String? token) async {
+    if (token == null) return _secure.delete(key: _tokenKey);
+    await _secure.write(key: _tokenKey, value: token);
+  }
+
+  Future<String?> readToken() async {
+    final v = await _secure.read(key: _tokenKey);
+    if (v != null) return v;
+    // One-time migration from the old plaintext location.
+    final prefs = await SharedPreferences.getInstance();
+    final legacy = prefs.getString(_tokenKey);
+    if (legacy != null) {
+      await _secure.write(key: _tokenKey, value: legacy);
+      await prefs.remove(_tokenKey);
+      return legacy;
+    }
+    return null;
+  }
+
+  Future<void> writeIdentity({String? userId, String? accountType, String? mobile}) async {
+    if (userId != null) await _secure.write(key: _userIdKey, value: userId);
+    if (accountType != null) await _secure.write(key: _accountTypeKey, value: accountType);
+    if (mobile != null) await _secure.write(key: _mobileKey, value: mobile);
+  }
+
+  Future<Map<String, String?>> readIdentity() async {
+    return {
+      'userId': await _secure.read(key: _userIdKey),
+      'accountType': await _secure.read(key: _accountTypeKey),
+      'mobile': await _secure.read(key: _mobileKey),
+    };
+  }
+
+  Future<void> clear() async {
+    await _secure.delete(key: _tokenKey);
+    await _secure.delete(key: _userIdKey);
+    await _secure.delete(key: _accountTypeKey);
+    await _secure.delete(key: _mobileKey);
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,10 +4,12 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  flutter_secure_storage_linux
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,16 @@ import Foundation
 
 import device_info_plus
 import file_selector_macos
+import flutter_secure_storage_macos
+import path_provider_foundation
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -326,6 +326,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.24"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_spinkit:
     dependency: transitive
     description:
@@ -504,14 +552,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -580,18 +644,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -640,6 +704,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -921,10 +1009,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:
@@ -1086,5 +1174,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   font_awesome_flutter: ^10.7.0
   permission_handler: ^11.3.0
   internet_connection_checker: ^1.0.0+1
+  flutter_secure_storage: ^9.2.2
 
 
   # Use with the CupertinoIcons class for iOS style icons.

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,15 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_windows/file_selector_windows.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,11 +4,13 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
+  flutter_secure_storage_windows
   permission_handler_windows
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## Summary

Move auth bearer tokens from `SharedPreferences` (plaintext) to platform secure storage — Keychain on iOS, encrypted SharedPreferences on Android — via `flutter_secure_storage`. Includes a one-time migration: any legacy plaintext token is read, rewritten to secure storage, and removed from prefs on first `readToken()` call. Profile fields (user id, mobile, account type, etc.) remain in `SharedPreferences`.

### Changes
- New `lib/services/secure_token_store.dart` — singleton service wrapping `FlutterSecureStorage` with `readToken` / `writeToken` / `readIdentity` / `writeIdentity` / `clear`
- `lib/providers/auth_provider.dart` — routed through `SecureTokenStore` for initialize / setAuthData / clearAuth
- `pubspec.yaml` — add `flutter_secure_storage: ^9.2.2`
- `pubspec.lock` regenerated; plugin registrants for `linux/`, `macos/`, `windows/` updated by `flutter pub get`

### Why
Tokens in `SharedPreferences` are visible to anyone with shell-level access or with a rooted device. For a payments-adjacent app this was a standing gap identified in the mobile security review.

## Verification

- `flutter analyze lib/providers/auth_provider.dart lib/services/secure_token_store.dart` clean

## Test plan

- [ ] On a device with a previous version installed, launch the new build — the auth token should silently migrate; user stays logged in
- [ ] Fresh install + login — token persists across app restarts
- [ ] Logout — `SecureTokenStore.clear()` removes the token
- [ ] iOS build succeeds on CI or locally (Keychain access group)
- [ ] Android minSdk and the `encryptedSharedPreferences: true` option still resolve cleanly