### PR TITLE
p0: Material 3 theme scaffold (seed #2C3E50)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:aultra_paints_mobile/services/UserViewModel.dart';
 import 'package:aultra_paints_mobile/screens/cart/CartScreen.dart';
 import 'package:aultra_paints_mobile/providers/cart_provider.dart';
 import 'package:aultra_paints_mobile/providers/auth_provider.dart';
+import 'package:aultra_paints_mobile/theme/app_theme.dart';
 
 import '/screens/authentication/otp/OtpPage.dart';
 import 'screens/myOrders/myOrdersPage.dart';
@@ -70,9 +71,9 @@ class MyApp extends StatelessWidget {
       builder: EasyLoading.init(),
       // title: '',
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        platform: TargetPlatform.iOS,
-      ),
+      theme: AppTheme.light,
+      darkTheme: AppTheme.dark,
+      themeMode: ThemeMode.system,
       home: const SplashPage(),
       // home: const DashboardPage(),
       routes: {

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+/// Single source of truth for theme seed and any brand-fixed accents.
+///
+/// The primary seed is the Aultra brand slate blue used in the legacy
+/// palette (`lib/utility/Colors.dart` -> `appColor`, `appThemeColor`).
+/// All Material 3 colour roles are derived from it via
+/// `ColorScheme.fromSeed`.
+class AppColors {
+  AppColors._();
+
+  static const Color seed = Color(0xFF2C3E50);
+}

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+import 'app_colors.dart';
+
+/// Centralised Material 3 theme. Screens continue to use existing
+/// hard-coded colours from `lib/utility/Colors.dart`; per-screen colour
+/// cleanup is deferred to Phase 1.
+class AppTheme {
+  AppTheme._();
+
+  static ThemeData get light => ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.seed,
+          brightness: Brightness.light,
+        ),
+      );
+
+  static ThemeData get dark => ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppColors.seed,
+          brightness: Brightness.dark,
+        ),
+      );
+}


### PR DESCRIPTION
## Summary

Drop in a Material 3 theme baseline. No screen restyling.

- `lib/theme/app_colors.dart` — `AppColors.seed = Color(0xFF2C3E50)` (dominant brand slate blue from `lib/utility/Colors.dart`)
- `lib/theme/app_theme.dart` — `AppTheme.light` and `AppTheme.dark` built from `ColorScheme.fromSeed(...)` with `useMaterial3: true`
- `lib/main.dart` — `MaterialApp.theme` / `darkTheme` / `themeMode: ThemeMode.system` wired in; the previous `ThemeData(platform: TargetPlatform.iOS)` override is removed (Flutter auto-detects)

### What does NOT change
- No design-system widgets (`AppButton`, `AppCard`, etc.) — deferred to Phase 1
- No per-screen colour cleanup — existing hardcoded colours from `lib/utility/Colors.dart` keep working; per-screen adaptation is P1 work
- No typography or spacing token system

### Expected visual differences
Material 3 alters button shapes (rounded-squircle), ink ripples, and the default `AppBar` shape. These are cosmetic. Screens with explicit hardcoded colours render the same as before.

Dark mode ships enabled and system-driven. If too many screens break in dark, mitigation is a one-line change to pin `themeMode: ThemeMode.light`.

## Verification

- `flutter analyze lib/main.dart lib/theme/` — no issues in touched files

## Test plan

- [ ] Launch the app on a physical Android device, walk: Splash → Launch → Login → OTP → Dashboard → Cart → Orders → Profile in **light** mode. Note any broken layout.
- [ ] Repeat in **dark** mode (switch system appearance).
- [ ] Document any regressions in a follow-up issue; pin `ThemeMode.light` only if something is unusable.
- [ ] iOS build check on at least one device — some `AppBar` / `Scaffold` defaults render differently on Cupertino platforms.