### PR TITLE
p0: delete live print() calls across 17 files

### DIFF
--- a/lib/providers/cart_provider.dart
+++ b/lib/providers/cart_provider.dart
@@ -82,7 +82,6 @@ class CartProvider with ChangeNotifier {
           // print(
           //     'Saving cart for previous user: $_userId with ${_items.length} items');
           await saveCart();
-          print('Previous cart saved successfully');
         }
 
         _items = {};
@@ -93,11 +92,8 @@ class CartProvider with ChangeNotifier {
         }
 
         notifyListeners();
-      } else {
-        print('User ID unchanged, skipping cart reload');
       }
     } catch (e) {
-      print('Error in setUserId: $e');
       _items = {};
       notifyListeners();
     }
@@ -125,20 +121,16 @@ class CartProvider with ChangeNotifier {
                 }
               }
             } catch (e) {
-              print('Error loading cart item $key: $e');
             }
           });
 
           // Merge loaded items with existing items
           _items.addAll(loadedItems);
-          print('Successfully loaded ${_items.length} items');
           notifyListeners();
         } catch (e) {
-          print('Error decoding cart data: $e');
         }
       }
     } catch (e) {
-      print('Error loading cart data: $e');
     }
   }
 
@@ -158,18 +150,15 @@ class CartProvider with ChangeNotifier {
       final encodedData = json.encode(cartData);
       await prefs.setString(cartKey, encodedData);
     } catch (e) {
-      print('Error saving cart data: $e');
     }
   }
 
   void addItem(String productId, String name, double price, String imageUrl) {
     if (productId.isEmpty || _userId == null) {
-      print('Cannot add item: productId is empty or no user is set');
       return;
     }
 
     if (name.isEmpty || price <= 0 || imageUrl.isEmpty) {
-      print('Cannot add item: invalid product data');
       return;
     }
 
@@ -187,8 +176,6 @@ class CartProvider with ChangeNotifier {
           );
           saveCart();
           notifyListeners();
-          print(
-              'Updated quantity for existing item: $productId to ${existingItem.quantity + 1}');
         }
       } else {
         // Add new item
@@ -201,10 +188,8 @@ class CartProvider with ChangeNotifier {
         );
         saveCart();
         notifyListeners();
-        print('Added new item to cart: $productId');
       }
     } catch (e) {
-      print('Error adding/updating item in cart: $e');
     }
   }
 
@@ -282,6 +267,5 @@ class CartProvider with ChangeNotifier {
     _items = {};
     saveCart();
     notifyListeners();
-    print('Cleared cart');
   }
 }

--- a/lib/screens/authentication/login/LoginPage.dart
+++ b/lib/screens/authentication/login/LoginPage.dart
@@ -104,7 +104,6 @@ class _LoginPageState extends State<LoginPage> {
       }
     } catch (e) {
       Loader.hideLoader(context);
-      print('Error: $e');
       error_handling.errorValidation(context, '', e.toString(), false);
     }
   }

--- a/lib/screens/authentication/otp/OtpPage.dart
+++ b/lib/screens/authentication/otp/OtpPage.dart
@@ -105,15 +105,11 @@ class _OtpPageState extends State<OtpPage> {
     http.Response response;
     Map map = {"mobile": loggedUserPhoneNumber, "otp": int.parse(otpCodes)};
     var body = json.encode(map);
-    print('otp body===>${body}');
     response = await http.post(Uri.parse(BASE_URL + POST_VERIFY_LOGIN_OTP),
         headers: {"Content-Type": "application/json"}, body: body);
     stringResponse = response.body;
-    print(
-        'otp stringResponse ==== $stringResponse =====>${response.statusCode}');
     mapResponse = json.decode(response.body);
     if (response.statusCode == 200 || response.statusCode == 201) {
-      print('otp resp ==== $mapResponse');
       Navigator.pop(context);
       _showSnackBar(mapResponse['message'], context, true);
       onSuccess(mapResponse);
@@ -124,7 +120,6 @@ class _OtpPageState extends State<OtpPage> {
   }
 
   onSuccess(userData) async {
-    print('userdata structure====>${json.encode(userData)}');
     FocusScope.of(context).unfocus();
 
     final authProvider = Provider.of<AuthProvider>(context, listen: false);

--- a/lib/screens/authentication/signup/SignupPage.dart
+++ b/lib/screens/authentication/signup/SignupPage.dart
@@ -81,7 +81,6 @@ class _SignupPageState extends State<SignupPage> {
       "mobile": _userMobileNumber.text
     };
     var body = json.encode(map);
-    print('register body===>$body');
     response = await http.post(Uri.parse(BASE_URL + REGISTER_USER),
         headers: {"Content-Type": "application/json"}, body: body);
     // print('register statusCode====>${response.statusCode}');

--- a/lib/screens/cart/CartScreen.dart
+++ b/lib/screens/cart/CartScreen.dart
@@ -113,14 +113,10 @@ class _CartScreenState extends State<CartScreen> {
         if (responseData['success'] == true && responseData['data'] != null) {
           setState(() {
             focusEntities = List<Map<String, dynamic>>.from(responseData['data']);
-            print('${focusEntities}');
           });
         }
-      } else {
-        print('Failed to load focus entities: ${response.statusCode}');
       }
     } catch (e) {
-      print('Error fetching focus entities: $e');
     } finally {
       setState(() {
         isFocusEntitiesLoading = false;
@@ -705,7 +701,6 @@ class _CartScreenState extends State<CartScreen> {
                       ),
                       onPressed: () {
                         if (USER_ACCOUNT_TYPE == 'SalesExecutive') {
-                          print('${cart.items.isEmpty} ${widget.dealer['_id']} ${selectedFocusEntity}');
                           if (cart.items.isEmpty || widget.dealer['_id'] == null || selectedFocusEntity == null) {
                             if (cart.items.isEmpty) {
                               _showSnackBar('Cart is empty', context, false);

--- a/lib/screens/catalog/ProductsCatalogScreen.dart
+++ b/lib/screens/catalog/ProductsCatalogScreen.dart
@@ -120,8 +120,6 @@ class _ProductsCatalogScreenState extends State<ProductsCatalogScreen> {
     http.Response response;
     var apiUrl = BASE_URL + GET_CATALOG_SEARCH;
 
-    print('-----------------------------${selectedDealerId}');
-
     try {
       response = await http.post(
         Uri.parse(apiUrl),
@@ -131,7 +129,6 @@ class _ProductsCatalogScreenState extends State<ProductsCatalogScreen> {
 
       if (response.statusCode == 200) {
         final responseData = json.decode(response.body);
-        print('catalog responseData====>${responseData}  ');
         setState(() {
           // Ensure each offer has a valid ID
           var data = responseData['data'] as List;
@@ -216,7 +213,6 @@ class _ProductsCatalogScreenState extends State<ProductsCatalogScreen> {
                                     orElse: () => <dynamic, dynamic>{},
                                   );
                                 }
-                                print('=================${dealer}');
                                 Navigator.push(
                                   context,
                                   MaterialPageRoute(builder: (context) => CartScreen(dealer)),
@@ -862,12 +858,8 @@ class _ProductsCatalogScreenState extends State<ProductsCatalogScreen> {
 
       if (response.statusCode == 200) {
         final responseData = json.decode(response.body);
-        print('productOffers ------ responseData====>${responseData}');
         setState(() {
           dealers = responseData['data'] ?? [];
-          if (kDebugMode) {
-            print("====================${dealers}");
-          }
         });
         setState(() => dealersLoading = false);
       } else if (response.statusCode == 401) {

--- a/lib/screens/dashboard/DashboardNewPage.dart
+++ b/lib/screens/dashboard/DashboardNewPage.dart
@@ -162,13 +162,11 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
 
   Future<void> getDashboardDetails() async {
     if (USER_ID == null || USER_ID.isEmpty) {
-      print('Missing user ID for dashboard details');
       return;
     }
 
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     if (!authProvider.isAuthenticated) {
-      print('User not authenticated');
       return;
     }
 
@@ -270,7 +268,6 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
 
       if (response.statusCode == 200) {
         final responseData = json.decode(response.body);
-        print('productOffers responseData====>${responseData}');
         setState(() {
           // Ensure each offer has a valid ID
           var data = responseData['data'] as List;

--- a/lib/screens/dashboard/DashboardPage.dart
+++ b/lib/screens/dashboard/DashboardPage.dart
@@ -218,7 +218,6 @@ class _DashboardPageState extends State<DashboardPage> {
         if (response.statusCode == 400) {
           // throw Exception("Failed to fetch Dealer Code. Status code");
           final responseData = json.decode(response.body);
-          print(responseData['message']);
           _showSnackBar(
             "${responseData['message']}.",
             context,
@@ -231,7 +230,6 @@ class _DashboardPageState extends State<DashboardPage> {
         }
       }
     } catch (error) {
-      print("Error fetching OTP: $error");
       Navigator.pop(context);
       throw Exception("An error occurred while requesting OTP.");
     }
@@ -271,7 +269,6 @@ class _DashboardPageState extends State<DashboardPage> {
             "Failed to save details. Status code: ${response.statusCode}");
       }
     } catch (error) {
-      print("Error saving dealer details: $error");
       throw Exception("An error occurred while saving dealer details.");
     }
   }
@@ -828,7 +825,6 @@ class _DashboardPageState extends State<DashboardPage> {
 
   void showPopupForDealerCode(
       BuildContext context, Map<String, dynamic> response) {
-    print('${!response['dealerCode'].isEmpty}=========>');
     final
         // showPopupForDealerCode(context, {'dealerCode': parentDealerCode, 'dealerName': userParentDealerName});
 

--- a/lib/screens/dashboard/PainterPopUpPage.dart
+++ b/lib/screens/dashboard/PainterPopUpPage.dart
@@ -124,8 +124,6 @@ class _PainterPopUpPageState extends State<PainterPopUpPage> {
       },
       body: tempBody,
     );
-    print(
-        'tempBody====>${tempBody}====>${response.statusCode}====>${response.body}');
     if (response.statusCode == 200) {
       final responseData = json.decode(response.body);
       Navigator.pop(context);

--- a/lib/screens/launch/launchPage.dart
+++ b/lib/screens/launch/launchPage.dart
@@ -67,7 +67,6 @@ class _LaunchPageState extends State<LaunchPage> {
           .load('assets/certificate/AultraPaints_b20bd50c61d9d911.crt'); //QA
       context.setTrustedCertificatesBytes(certData.buffer.asUint8List());
     } catch (e) {
-      print("Error loading certificate: $e");
       throw Exception("Failed to load certificate");
     }
     return HttpClient(context: context)

--- a/lib/screens/myOrders/OrderDetailsScreen.dart
+++ b/lib/screens/myOrders/OrderDetailsScreen.dart
@@ -60,8 +60,6 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
 
       if (!mounted) return;
 
-      print('order/details response====>${response.body}');
-
       if (response.statusCode == 200) {
         final responseData = json.decode(response.body);
         setState(() {
@@ -77,8 +75,6 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
             context, response.statusCode, response.body, false);
       }
     } catch (e) {
-      // ignore: avoid_print
-      print('Error fetching order details: $e');
     } finally {
       if (mounted) setState(() => isOrderLoading = false);
     }
@@ -89,7 +85,6 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
     final order = orderDetails ?? widget.order;
     final accountType =
         Provider.of<AuthProvider>(context).userAccountType ?? '';
-    print('accountType====>${accountType}');
     final String orderId = order['orderId']?.toString() ?? '-';
 
     final String status =
@@ -554,14 +549,10 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
           setState(() {
             focusEntities =
                 List<Map<String, dynamic>>.from(responseData['data']);
-            print('${focusEntities}');
           });
         }
-      } else {
-        print('Failed to load focus entities: ${response.statusCode}');
       }
     } catch (e) {
-      print('Error fetching focus entities: $e');
     } finally {
       setState(() {
         isFocusEntitiesLoading = false;

--- a/lib/screens/myOrders/myOrdersPage.dart
+++ b/lib/screens/myOrders/myOrdersPage.dart
@@ -110,7 +110,6 @@ class _MyOrdersPageState extends State<MyOrdersPage>
       );
       if (response.statusCode == 200) {
         final responseData = json.decode(response.body);
-        print('responseData======>${responseData}');
 
         if (responseData['orders'] is List) {
           List<dynamic> newData = responseData['orders'];

--- a/lib/screens/orders/ordersList/OrdersList.dart
+++ b/lib/screens/orders/ordersList/OrdersList.dart
@@ -118,8 +118,7 @@ class _OrdersListState extends State<OrdersList> {
     response = await http.get(Uri.parse(BASE_URL + GET_ORDERS), headers: {
       "Content-Type": "application/json",
       "Authorization": accesstoken
-    }); 
-    print('${BASE_URL + GET_ORDERS}==== list resp==>${response.statusCode}');
+    });
 
     if (response.statusCode == 200) {
       Navigator.pop(context);
@@ -127,7 +126,6 @@ class _OrdersListState extends State<OrdersList> {
         stringResponse = response.body;
         mapResponse = json.decode(response.body);
         ordersList = mapResponse['data'];
-        print('ordersList=====>${ordersList}');
       });
     } else {
       Navigator.pop(context);

--- a/lib/screens/orders/qrScanner/QrScanner.dart
+++ b/lib/screens/orders/qrScanner/QrScanner.dart
@@ -138,8 +138,6 @@ class _QrScannerState extends State<QrScanner> {
                             : QrCamera(
                                 qrCodeCallback: (code) {
                                   HapticFeedback.vibrate();
-                                  print(
-                                      'scanned code==== $code, ${code.runtimeType}');
                                   if (code != null) {
                                     setState(() {
                                       allowScanner = false;

--- a/lib/screens/painter/PainterPage.dart
+++ b/lib/screens/painter/PainterPage.dart
@@ -71,7 +71,6 @@ class _PainterPageState extends State<PainterPage> {
 
       if (response.statusCode == 200) {
         final responseData = json.decode(response.body);
-        print('${responseData}======================================');
         if (responseData['data'] is List) {
           setState(() {
             myPainterList.addAll(responseData['data']);

--- a/lib/services/WidgetScreens/DealerSearchDialog.dart
+++ b/lib/services/WidgetScreens/DealerSearchDialog.dart
@@ -118,8 +118,6 @@ class _DealerSearchDialogState extends State<DealerSearchDialog> {
       },
       body: tempBody,
     );
-    print(
-        'tempBody====>${tempBody}====>${response.statusCode}====>${response.body}');
     if (response.statusCode == 200) {
       final responseData = json.decode(response.body);
       Navigator.pop(context);
@@ -174,7 +172,6 @@ class _DealerSearchDialogState extends State<DealerSearchDialog> {
   // }
 
   Future<void> verifyOtp(String otp) async {
-    print("${selectedDealer}<><><><><><><><><><><><><><><>${otp}");
     Utils.clearToasts(context);
     Utils.returnScreenLoader(context);
     http.Response response;

--- a/lib/services/error_handling.dart
+++ b/lib/services/error_handling.dart
@@ -16,7 +16,6 @@ class error_handling {
 
   static errorValidation(context, statusCode, message, messageType) async {
     // Utils.clearToasts(context);
-    print('statusCode: $statusCode');
     if (statusCode == 401 || statusCode == 502) {
       _showSnackBar(message, context, messageType);
       clearStorage(context);


### PR DESCRIPTION
## Summary

Remove **52 live `print()` statements** across 17 files in `lib/`. These leaked to `logcat` / `idevicesyslog` in production builds. A follow-up PR will enable the `avoid_print` Dart lint to prevent regressions.

### Scope rules applied
- Deleted every live `print(...)` line (including multi-line prints).
- Left surrounding `try/catch` and error-handling logic intact.
- **Kept** local variables whose only use was the deleted print — a separate cleanup pass can tidy them later.
- **Did not touch** commented-out `// print(...)` lines (inert).
- **Did not touch** `debugPrint(...)` calls (no-op in release by Flutter convention).

### What happens to empty `catch (e) { }` blocks
Some blocks had only `print(...)` inside. Those are now empty catches that silently swallow errors. The runtime behaviour is unchanged (a `print` was not functional error handling), but the silent-swallow pattern is worth revisiting in Phase 1.

### Files changed (17)
`cart_provider.dart`, `LoginPage.dart`, `OtpPage.dart`, `SignupPage.dart`, `CartScreen.dart`, `ProductsCatalogScreen.dart`, `DashboardNewPage.dart`, `DashboardPage.dart`, `PainterPopUpPage.dart`, `launchPage.dart`, `OrderDetailsScreen.dart`, `myOrdersPage.dart`, `OrdersList.dart`, `QrScanner.dart`, `PainterPage.dart`, `DealerSearchDialog.dart`, `error_handling.dart`

## Verification

- `rg '^\s*print\(' lib/` → zero hits
- `flutter analyze` — no new errors; pre-existing warnings unchanged

## Test plan

- [ ] Login → OTP → Dashboard
- [ ] Add items to cart → checkout
- [ ] View orders list → order detail
- [ ] Launch QR scanner (no crash, no missing output)
- [ ] Trigger a cart-item load failure scenario (if reproducible) and confirm the catch block handles it without user-visible breakage