### PR TITLE
feat(orders): SuperUser orders access + status & dealer filters in MyOrdersPage

### DIFF
--- a/lib/screens/LayOut/LayOutPage.dart
+++ b/lib/screens/LayOut/LayOutPage.dart
@@ -251,7 +251,7 @@ class _AppDrawer extends StatelessWidget {
                       Navigator.pushNamed(context, '/pointsLedgerPage');
                     },
                   ),
-                  if (accountType == 'Dealer' || accountType == 'SalesExecutive')
+                  if (accountType == 'Dealer' || accountType == 'SalesExecutive' || accountType == 'SuperUser')
                     _drawerItem(
                       context,
                       icon: Icons.receipt_long_outlined,

--- a/lib/screens/myOrders/myOrdersPage.dart
+++ b/lib/screens/myOrders/myOrdersPage.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
-import 'dart:async';
 
 import 'package:aultra_paints_mobile/screens/myOrders/OrderDetailsScreen.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
 
+import '../../providers/auth_provider.dart';
 import '../../services/config.dart';
 import '../../services/secure_token_store.dart';
 import '../../services/error_handling.dart';
@@ -14,6 +15,9 @@ import '../../theme/app_spacing.dart';
 import '../../widgets/primitives/app_badge.dart';
 import '../../widgets/primitives/app_empty_state.dart';
 import '../../widgets/primitives/app_list_row.dart';
+
+const _kStatusOptions = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'IN-PARCEL'];
+const _kPageSize = 20;
 
 AppBadgeTone _toneForStatus(String? s) {
   switch ((s ?? '').toUpperCase()) {
@@ -43,24 +47,47 @@ class MyOrdersPage extends StatefulWidget {
   _MyOrdersPageState createState() => _MyOrdersPageState();
 }
 
-class _MyOrdersPageState extends State<MyOrdersPage>
-    with WidgetsBindingObserver {
+class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
-  Timer? _debounce;
 
   String? accesstoken;
+  String accountType = '';
+
   List<dynamic> myOrdersList = [];
   int currentPage = 1;
   bool isLoading = false;
   bool hasMore = true;
+
+  String? statusFilter;
+  String? dealerCodeFilter;
+  List<Map<String, dynamic>> dealers = [];
+  String? dealersError;
+
+  int _fetchGeneration = 0;
+  int _loadersOnStack = 0;
+
   final ScrollController _scrollController = ScrollController();
+
+  bool get _showFilters =>
+      accountType == 'SuperUser' || accountType == 'SalesExecutive';
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    fetchLocalStorageData();
     _scrollController.addListener(_scrollListener);
+    _bootstrap();
+  }
+
+  Future<void> _bootstrap() async {
+    accesstoken = await SecureTokenStore.instance.readToken();
+    if (!mounted) return;
+    final auth = Provider.of<AuthProvider>(context, listen: false);
+    accountType = auth.userAccountType ?? '';
+    if (_showFilters) {
+      _loadDealers();
+    }
+    await _fetchPage();
   }
 
   void _scrollListener() {
@@ -68,77 +95,114 @@ class _MyOrdersPageState extends State<MyOrdersPage>
             _scrollController.position.maxScrollExtent - 200 &&
         !isLoading &&
         hasMore) {
-      getMyOrdersList();
+      _fetchPage();
     }
   }
 
   @override
   void dispose() {
+    _loadersOnStack = 0;
     WidgetsBinding.instance.removeObserver(this);
     _scrollController.dispose();
-    _debounce?.cancel();
     super.dispose();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
-      _reloadOrders();
+      _resetAndReload();
     }
   }
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _reloadOrders();
-  }
-
-  void _reloadOrders() async {
-    setState(() {
-      myOrdersList.clear();
-      currentPage = 1;
-      hasMore = true;
-    });
-    await fetchLocalStorageData();
-  }
-
-  Future<void> fetchLocalStorageData() async {
-    accesstoken = await SecureTokenStore.instance.readToken();
-    await getMyOrdersList();
-  }
-
-  Future<void> getMyOrdersList() async {
-    if (isLoading || accesstoken == null || !hasMore) return;
-    setState(() => isLoading = true);
-
-    bool loaderShown = false;
+  Future<void> _loadDealers() async {
     try {
-      Utils.returnScreenLoader(context);
-      loaderShown = true;
-
-      final apiUrl = BASE_URL + GET_CART_ORDERS_LIST;
-      var query = {
-        'page': currentPage,
-        'limit': 1000,
-      };
-      final response = await http.post(
-        Uri.parse(apiUrl),
+      final response = await http.get(
+        Uri.parse(BASE_URL + GET_ORDER_DEALERS),
         headers: {
           "Content-Type": "application/json",
           "Authorization": accesstoken!,
         },
-        body: json.encode(query),
       );
       if (response.statusCode == 200) {
-        final responseData = json.decode(response.body);
+        final data = json.decode(response.body);
+        final list = (data['dealers'] as List?) ?? [];
+        if (mounted) {
+          setState(() {
+            dealers = list.cast<Map<String, dynamic>>();
+            dealersError = null;
+          });
+        }
+      } else {
+        if (mounted) setState(() => dealersError = 'Could not load dealers');
+      }
+    } catch (_) {
+      if (mounted) setState(() => dealersError = 'Could not load dealers');
+    }
+  }
 
+  Future<void> _resetAndReload() async {
+    if (!mounted) return;
+    // Pop any in-flight loader the stale fetch pushed; that fetch will discard
+    // its response on the generation check and won't try to pop again.
+    while (_loadersOnStack > 0 && mounted) {
+      Navigator.pop(context);
+      _loadersOnStack--;
+    }
+    setState(() {
+      myOrdersList.clear();
+      currentPage = 1;
+      hasMore = true;
+      isLoading = false; // abandon any in-flight fetch's local state guard
+    });
+    _fetchGeneration++;
+    await _fetchPage();
+  }
+
+  Future<void> _fetchPage() async {
+    if (isLoading || accesstoken == null || !hasMore) return;
+    final myGen = _fetchGeneration;
+    setState(() => isLoading = true);
+
+    bool loaderShown = false;
+    try {
+      if (mounted && currentPage == 1) {
+        Utils.returnScreenLoader(context);
+        loaderShown = true;
+        _loadersOnStack++;
+      }
+
+      final body = <String, dynamic>{
+        'page': currentPage,
+        'limit': _kPageSize,
+      };
+      if (statusFilter != null && statusFilter!.isNotEmpty) {
+        body['status'] = statusFilter;
+      }
+      if (dealerCodeFilter != null && dealerCodeFilter!.isNotEmpty) {
+        body['dealerCode'] = dealerCodeFilter;
+      }
+
+      final response = await http.post(
+        Uri.parse(BASE_URL + GET_CART_ORDERS_LIST),
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": accesstoken!,
+        },
+        body: json.encode(body),
+      );
+
+      // Stale fetch — discard so we don't write into the post-reset state.
+      if (myGen != _fetchGeneration) return;
+
+      if (response.statusCode == 200) {
+        final responseData = json.decode(response.body);
         if (responseData['orders'] is List) {
-          List<dynamic> newData = responseData['orders'];
+          final List<dynamic> newData = responseData['orders'];
           if (mounted) {
             setState(() {
               myOrdersList.addAll(newData);
               currentPage++;
-              hasMore = newData.length >= 10;
+              hasMore = newData.length >= _kPageSize;
             });
           }
         }
@@ -151,6 +215,7 @@ class _MyOrdersPageState extends State<MyOrdersPage>
         );
       }
     } catch (error) {
+      if (myGen != _fetchGeneration) return;
       error_handling.errorValidation(
         context,
         'Failed to fetch orders',
@@ -158,13 +223,156 @@ class _MyOrdersPageState extends State<MyOrdersPage>
         false,
       );
     } finally {
-      if (mounted) {
+      if (mounted && myGen == _fetchGeneration) {
         setState(() => isLoading = false);
       }
-      if (loaderShown) {
+      // Only pop the loader if THIS fetch still owns it.
+      if (loaderShown && mounted && myGen == _fetchGeneration && _loadersOnStack > 0) {
         Navigator.pop(context);
+        _loadersOnStack--;
       }
     }
+  }
+
+  void _onStatusChanged(String? value) {
+    setState(() => statusFilter = (value == null || value.isEmpty) ? null : value);
+    _resetAndReload();
+  }
+
+  void _onDealerChanged(String? code) {
+    setState(() => dealerCodeFilter = (code == null || code.isEmpty) ? null : code);
+    _resetAndReload();
+  }
+
+  void _clearFilters() {
+    if (statusFilter == null && dealerCodeFilter == null) return;
+    setState(() {
+      statusFilter = null;
+      dealerCodeFilter = null;
+    });
+    _resetAndReload();
+  }
+
+  String _labelForDealerCode(String code) {
+    final match = dealers.firstWhere(
+      (d) => d['dealerCode']?.toString() == code,
+      orElse: () => <String, dynamic>{},
+    );
+    if (match.isEmpty) return code;
+    return '${match['dealerCode']} — ${match['name'] ?? ''}';
+  }
+
+  Widget _buildDealerPicker() {
+    // Searchable Autocomplete (pattern reused from PainterPopUpPage.dart).
+    final selectedLabel = dealerCodeFilter == null
+        ? ''
+        : (() {
+            final match = dealers.firstWhere(
+              (d) => d['dealerCode']?.toString() == dealerCodeFilter,
+              orElse: () => <String, dynamic>{},
+            );
+            if (match.isEmpty) return dealerCodeFilter!;
+            return '${match['dealerCode']} — ${match['name'] ?? ''}';
+          })();
+
+    return Autocomplete<Map<String, dynamic>>(
+      key: ValueKey('dealer-${dealerCodeFilter ?? "all"}'),
+      initialValue: TextEditingValue(text: selectedLabel),
+      displayStringForOption: (d) =>
+          '${d['dealerCode']} — ${d['name'] ?? ''}',
+      optionsBuilder: (TextEditingValue value) {
+        final term = value.text.trim().toLowerCase();
+        if (term.isEmpty) return dealers.take(20);
+        return dealers.where((d) {
+          final code = (d['dealerCode'] ?? '').toString().toLowerCase();
+          final name = (d['name'] ?? '').toString().toLowerCase();
+          return code.contains(term) || name.contains(term);
+        }).take(20);
+      },
+      fieldViewBuilder: (ctx, controller, focus, onSubmit) {
+        return TextField(
+          controller: controller,
+          focusNode: focus,
+          decoration: InputDecoration(
+            labelText: 'Dealer',
+            border: const OutlineInputBorder(),
+            isDense: true,
+            suffixIcon: (controller.text.isEmpty)
+                ? null
+                : IconButton(
+                    icon: const Icon(Icons.clear, size: 18),
+                    onPressed: () {
+                      controller.clear();
+                      _onDealerChanged(null);
+                    },
+                  ),
+          ),
+          onChanged: (value) {
+            if (dealerCodeFilter == null) return;
+            if (value == _labelForDealerCode(dealerCodeFilter!)) return;
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              // Re-check after frame; user may have selected meanwhile.
+              if (dealerCodeFilter != null &&
+                  controller.text != _labelForDealerCode(dealerCodeFilter!)) {
+                _onDealerChanged(null);
+              }
+            });
+          },
+        );
+      },
+      onSelected: (d) => _onDealerChanged(d['dealerCode']?.toString()),
+    );
+  }
+
+  Widget _buildFilterBar() {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        AppSpacing.md, AppSpacing.sm, AppSpacing.md, AppSpacing.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: DropdownButtonFormField<String?>(
+                  value: statusFilter,
+                  isExpanded: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Status',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  items: [
+                    const DropdownMenuItem<String?>(value: null, child: Text('All')),
+                    ..._kStatusOptions.map(
+                      (s) => DropdownMenuItem<String?>(value: s, child: Text(s)),
+                    ),
+                  ],
+                  onChanged: _onStatusChanged,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(child: _buildDealerPicker()),
+            ],
+          ),
+          if (dealersError != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(dealersError!, style: const TextStyle(fontSize: 12, color: Colors.grey)),
+            ),
+          if (statusFilter != null || dealerCodeFilter != null)
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: _clearFilters,
+                child: const Text('Clear filters'),
+              ),
+            ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -174,6 +382,7 @@ class _MyOrdersPageState extends State<MyOrdersPage>
       backgroundColor: AppColors.surface,
       body: Column(
         children: [
+          if (_showFilters) _buildFilterBar(),
           Expanded(
             child: myOrdersList.isEmpty && !isLoading
                 ? AppEmptyState(
@@ -182,58 +391,39 @@ class _MyOrdersPageState extends State<MyOrdersPage>
                     message: 'Your orders will appear here.',
                   )
                 : RefreshIndicator(
-                    onRefresh: () async => _reloadOrders(),
+                    onRefresh: () async => _resetAndReload(),
                     child: ListView.builder(
                       controller: _scrollController,
                       padding: EdgeInsets.all(AppSpacing.md),
-                      itemCount:
-                          myOrdersList.length + (hasMore ? 1 : 0),
+                      itemCount: myOrdersList.length + (hasMore ? 1 : 0),
                       itemBuilder: (context, i) {
                         if (i >= myOrdersList.length) {
                           return Padding(
-                            padding: EdgeInsets.all(16),
-                            child: Center(
-                              child: CircularProgressIndicator(
-                                  strokeWidth: 2),
-                            ),
+                            padding: const EdgeInsets.all(16),
+                            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
                           );
                         }
                         final order = myOrdersList[i];
-                        final String orderId =
-                            order['orderId']?.toString() ?? '-';
-                        final String status =
-                            (order['status'] ?? 'PENDING')
-                                .toString()
-                                .toUpperCase();
-                        final String total =
-                            order['totalPrice']?.toString() ?? '-';
-                        final String createdAt =
-                            order['createdAt'] != null
-                                ? Utils.formatDate(order['createdAt'])
-                                    .split(' ')[0]
-                                : '-';
+                        final orderId = order['orderId']?.toString() ?? '-';
+                        final status = (order['status'] ?? 'PENDING').toString().toUpperCase();
+                        final total = order['totalPrice']?.toString() ?? '-';
+                        final createdAt = order['createdAt'] != null
+                            ? Utils.formatDate(order['createdAt']).split(' ')[0]
+                            : '-';
                         return Padding(
-                          padding:
-                              EdgeInsets.only(bottom: AppSpacing.sm),
+                          padding: EdgeInsets.only(bottom: AppSpacing.sm),
                           child: AppListRow(
                             title: 'Order #$orderId',
-                            subtitle:
-                                '₹ $total · $createdAt',
-                            trailing: AppBadge(
-                              label: status,
-                              tone: _toneForStatus(status),
-                            ),
+                            subtitle: '₹ $total · $createdAt',
+                            trailing: AppBadge(label: status, tone: _toneForStatus(status)),
                             onTap: () async {
                               final result = await Navigator.push(
                                 context,
                                 MaterialPageRoute(
-                                  builder: (context) =>
-                                      OrderDetailsScreen(order: order),
+                                  builder: (_) => OrderDetailsScreen(order: order),
                                 ),
                               );
-                              if (result == true) {
-                                _reloadOrders();
-                              }
+                              if (result == true) _resetAndReload();
                             },
                           ),
                         );

--- a/lib/services/config.dart
+++ b/lib/services/config.dart
@@ -59,6 +59,8 @@ const UPDATE_ORDER_STATUS = "order/updateOrderStatus"; // update order status
 
 const GET_CART_ORDERS_LIST = "order/orders";
 
+const GET_ORDER_DEALERS = "order/dealers";
+
 const CREATE_CHECKOUT = "/order/create"; //checkout
 
 const GET_MY_PAINTERS = "users/getMyPainters";


### PR DESCRIPTION
## Summary
- Widens the drawer My Orders gate so SuperUser reaches the screen (was Dealer/SalesExecutive only).
- Adds a filter bar above the orders list (status dropdown + searchable Autocomplete dealer picker) for SuperUser and SalesExecutive. Dealer flow is unchanged.
- Replaces the prior `limit: 1000` heuristic with proper pagination at `_kPageSize = 20`; the existing infinite-scroll listener loads more on demand.
- Adds a fetch-generation counter so a filter change mid-fetch cannot stamp stale results into the cleared list, and a loader-stack tracker so the modal loader cannot pop the wrong route.
- Adds a dealer-input divergence guard so editing the field after a selection clears the stale filter.

## Depends on
- Backend: RunMyBus/aultra-paints-backend#153 — must merge first (provides `GET /order/dealers` and the new POST body fields).

## Test plan
- [x] `flutter analyze` reports zero errors / zero warnings; only pre-existing repo-wide info-level lints.
- [ ] Manual smoke on a device:
  - Dealer: filter bar hidden; list paginates 20 at a time on scroll (was 1000 in one shot).
  - SalesExecutive: filter bar shows status + dealer (mapped dealers only). Filter changes reset to page 1.
  - SuperUser: drawer entry now visible; filter bar shows status + all dealers; pagination, divergence guard, and Clear filters all work.
  - Pull-to-refresh keeps current filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)