### PR TITLE
feat(deals): show active deals dialog after login

### DIFF
--- a/lib/model/deal.dart
+++ b/lib/model/deal.dart
@@ -1,0 +1,39 @@
+class Deal {
+  final String id;
+  final String title;
+  final String dealImageUrl;
+  final DateTime? expirationDate;
+  final DateTime? updatedAt;
+
+  const Deal({
+    required this.id,
+    required this.title,
+    required this.dealImageUrl,
+    this.expirationDate,
+    this.updatedAt,
+  });
+
+  factory Deal.fromJson(Map<String, dynamic> json) {
+    return Deal(
+      id: json['_id']?.toString() ?? '',
+      title: json['title']?.toString() ?? '',
+      dealImageUrl: json['dealImageUrl']?.toString() ?? '',
+      expirationDate: json['expirationDate'] != null
+          ? DateTime.tryParse(json['expirationDate'].toString())
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.tryParse(json['updatedAt'].toString())
+          : null,
+    );
+  }
+
+  // Append `?v=<updatedAt-ms>` to bust the S3 cache when the admin updates
+  // a deal's image (the URL itself doesn't change because the S3 key is fixed
+  // to `${id}.png`).
+  String get cacheBustedImageUrl {
+    if (dealImageUrl.isEmpty) return '';
+    if (updatedAt == null) return dealImageUrl;
+    final separator = dealImageUrl.contains('?') ? '&' : '?';
+    return '$dealImageUrl${separator}v=${updatedAt!.millisecondsSinceEpoch}';
+  }
+}

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -13,6 +13,7 @@ class AuthProvider extends ChangeNotifier {
   String? _userParentDealerMobile;
   String? _userParentDealerName;
   bool _isInitialized = false;
+  bool _justLoggedIn = false;
 
   String? get accessToken => _accessToken;
   String? get userId => _userId;
@@ -24,6 +25,7 @@ class AuthProvider extends ChangeNotifier {
   String? get userParentDealerMobile => _userParentDealerMobile;
   String? get userParentDealerName => _userParentDealerName;
   bool get isInitialized => _isInitialized;
+  bool get justLoggedIn => _justLoggedIn;
 
   // Initialize auth state from storage. Token lives in secure storage now;
   // non-sensitive profile fields stay in SharedPreferences.
@@ -81,6 +83,20 @@ class AuthProvider extends ChangeNotifier {
     _userParentDealerName = userParentDealerName;
     _isInitialized = true;
 
+    notifyListeners();
+  }
+
+  /// Marks that the user just successfully completed the OTP login flow.
+  /// Consumed by DashboardNewPage to decide whether to fetch + show the
+  /// active-deals dialog. Not persisted — only valid for the current process.
+  void markJustLoggedIn() {
+    _justLoggedIn = true;
+    notifyListeners();
+  }
+
+  /// Clears the just-logged-in flag once the dashboard has handled it.
+  void clearJustLoggedIn() {
+    _justLoggedIn = false;
     notifyListeners();
   }
 

--- a/lib/screens/authentication/otp/OtpPage.dart
+++ b/lib/screens/authentication/otp/OtpPage.dart
@@ -132,6 +132,7 @@ class _OtpPageState extends State<OtpPage> {
     // Initialize cart with user ID
     await cartProvider.setUserId(userData['id']);
 
+    authProvider.markJustLoggedIn();
     Navigator.pushNamedAndRemoveUntil(
       context,
       '/dashboardPage',

--- a/lib/screens/dashboard/DashboardNewPage.dart
+++ b/lib/screens/dashboard/DashboardNewPage.dart
@@ -9,6 +9,8 @@ import 'package:http/http.dart' as http;
 
 import '../../providers/cart_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../services/deals_service.dart';
+import '../deals/ActiveDealsDialog.dart';
 import '../../services/error_handling.dart';
 import '../../utility/Utils.dart';
 import '../../services/config.dart';
@@ -95,6 +97,7 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
     });
 
     _startProductOffersAutoScroll();
+    _maybeShowActiveDealsAfterLogin();
   }
 
   void _startProductOffersAutoScroll() {
@@ -115,6 +118,25 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
           );
         }
       }
+    });
+  }
+
+  Future<void> _maybeShowActiveDealsAfterLogin() async {
+    // Wait until the first frame is painted so we have a usable BuildContext
+    // for showing the dialog over the dashboard.
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      if (!authProvider.justLoggedIn) return;
+      // Clear immediately so we never fire twice for the same login.
+      authProvider.clearJustLoggedIn();
+
+      final token = authProvider.accessToken;
+      if (token == null || token.isEmpty) return;
+
+      final deals = await DealsService.fetchActiveDeals(token);
+      if (!mounted || deals.isEmpty) return;
+      await ActiveDealsDialog.show(context, deals);
     });
   }
 

--- a/lib/screens/dashboard/DashboardNewPage.dart
+++ b/lib/screens/dashboard/DashboardNewPage.dart
@@ -75,6 +75,11 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
   final _productOffersController = PageController();
   double? _currentProductOffersPage = 0;
 
+  // Completed once getDashboardDetails has dismissed its loader (all exit paths).
+  // _maybeShowActiveDealsAfterLogin awaits this before pushing the deals dialog
+  // so the two dialogs never interleave on the Navigator stack.
+  final Completer<void> _dashboardReady = Completer<void>();
+
   @override
   void initState() {
     fetchLocalStorageData();
@@ -135,6 +140,10 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
       if (token == null || token.isEmpty) return;
 
       final deals = await DealsService.fetchActiveDeals(token);
+      // Wait until getDashboardDetails has dismissed its loader before pushing
+      // the deals dialog — prevents the pop in getDashboardDetails from landing
+      // on the deals dialog instead of the loader.
+      await _dashboardReady.future;
       if (!mounted || deals.isEmpty) return;
       await ActiveDealsDialog.show(context, deals);
     });
@@ -184,11 +193,13 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
 
   Future<void> getDashboardDetails() async {
     if (USER_ID == null || USER_ID.isEmpty) {
+      if (!_dashboardReady.isCompleted) _dashboardReady.complete();
       return;
     }
 
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     if (!authProvider.isAuthenticated) {
+      if (!_dashboardReady.isCompleted) _dashboardReady.complete();
       return;
     }
 
@@ -203,6 +214,7 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
 
       if (response.statusCode == 200) {
         Navigator.pop(context);
+        if (!_dashboardReady.isCompleted) _dashboardReady.complete();
         var tempResp = json.decode(response.body);
         var apiResp = tempResp['data'];
         setState(() {
@@ -250,15 +262,18 @@ class _DashboardNewPageState extends State<DashboardNewPage> {
         });
       } else if (response.statusCode == 401) {
         Navigator.pop(context);
+        if (!_dashboardReady.isCompleted) _dashboardReady.complete();
         await authProvider.clearAuth();
         Navigator.of(context).pushReplacementNamed('/login');
       } else {
         Navigator.pop(context);
+        if (!_dashboardReady.isCompleted) _dashboardReady.complete();
         error_handling.errorValidation(
             context, response.statusCode, response.body, false);
       }
     } catch (e) {
       Navigator.pop(context);
+      if (!_dashboardReady.isCompleted) _dashboardReady.complete();
       error_handling.errorValidation(context, 500,
           'An error occurred while fetching dashboard details', false);
     }

--- a/lib/screens/deals/ActiveDealsDialog.dart
+++ b/lib/screens/deals/ActiveDealsDialog.dart
@@ -1,0 +1,100 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import '../../model/deal.dart';
+
+class ActiveDealsDialog extends StatefulWidget {
+  final List<Deal> deals;
+
+  const ActiveDealsDialog({Key? key, required this.deals}) : super(key: key);
+
+  /// Shows the dialog. Safe to call when [deals] is empty (no-op).
+  static Future<void> show(BuildContext context, List<Deal> deals) {
+    if (deals.isEmpty) return Future.value();
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      builder: (_) => ActiveDealsDialog(deals: deals),
+    );
+  }
+
+  @override
+  State<ActiveDealsDialog> createState() => _ActiveDealsDialogState();
+}
+
+class _ActiveDealsDialogState extends State<ActiveDealsDialog> {
+  final PageController _controller = PageController();
+  int _currentPage = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final deals = widget.deals;
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 32),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: SizedBox(
+          width: double.maxFinite,
+          height: 480,
+          child: Column(
+            children: [
+              Expanded(
+                child: PageView.builder(
+                  controller: _controller,
+                  itemCount: deals.length,
+                  onPageChanged: (i) => setState(() => _currentPage = i),
+                  itemBuilder: (_, i) => Container(
+                    color: Colors.black,
+                    child: CachedNetworkImage(
+                      imageUrl: deals[i].cacheBustedImageUrl,
+                      fit: BoxFit.contain,
+                      placeholder: (_, __) => const Center(
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                      errorWidget: (_, __, ___) => const Center(
+                        child: Icon(Icons.broken_image, color: Colors.white54, size: 48),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: List.generate(deals.length, (i) {
+                        final isActive = i == _currentPage;
+                        return Container(
+                          margin: const EdgeInsets.symmetric(horizontal: 3),
+                          height: 8,
+                          width: isActive ? 20 : 8,
+                          decoration: BoxDecoration(
+                            color: isActive ? Colors.black87 : Colors.black26,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                        );
+                      }),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('Close'),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/myOrders/OrderDetailsScreen.dart
+++ b/lib/screens/myOrders/OrderDetailsScreen.dart
@@ -20,6 +20,8 @@ AppBadgeTone _toneForStatus(String? s) {
     case 'DELIVERED':
     case 'COMPLETED':
     case 'SUCCESS':
+    case 'DISPATCHED':
+    case 'MANUALLY_DISPATCHED':
       return AppBadgeTone.success;
     case 'FAILED':
     case 'CANCELLED':
@@ -30,6 +32,8 @@ AppBadgeTone _toneForStatus(String? s) {
     case 'IN_PROGRESS':
     case 'PROCESSING':
       return AppBadgeTone.info;
+    case 'PARTIALLY_DISPATCHED':
+      return AppBadgeTone.neutral;
     default:
       return AppBadgeTone.neutral;
   }
@@ -172,9 +176,9 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
       );
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
-        if (data['success'] == true && data['warehouses'] != null) {
+        if (data['success'] == true && data['branches'] != null) {
           setState(() {
-            focusBranches = List<Map<String, dynamic>>.from(data['warehouses']);
+            focusBranches = List<Map<String, dynamic>>.from(data['branches']);
           });
         }
       }
@@ -448,14 +452,7 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
                         padding: EdgeInsets.all(AppSpacing.sm),
                         child: Row(
                           children: [
-                            Container(
-                              width: 44,
-                              height: 44,
-                              decoration: BoxDecoration(
-                                color: AppColors.infoBg,
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                            ),
+                            _itemImage(item),
                             SizedBox(width: AppSpacing.sm),
                             Expanded(
                               child: Column(
@@ -506,6 +503,100 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
                         ),
                       ),
                     ),
+
+                  // --- Branch ---
+                  if (orderDetails?['branchName'] != null) ...[
+                    SizedBox(height: AppSpacing.lg),
+                    Text(
+                      'BRANCH',
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelSmall!
+                          .copyWith(color: AppColors.onSurfaceVariant),
+                    ),
+                    SizedBox(height: AppSpacing.xs),
+                    AppCard(
+                      padding: EdgeInsets.all(AppSpacing.md),
+                      child: Text(
+                        orderDetails!['branchName'].toString(),
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
+
+                  // --- Status History ---
+                  if (order['statusHistory'] != null &&
+                      (order['statusHistory'] as List).isNotEmpty) ...[
+                    SizedBox(height: AppSpacing.lg),
+                    Text(
+                      'STATUS HISTORY',
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelSmall!
+                          .copyWith(color: AppColors.onSurfaceVariant),
+                    ),
+                    SizedBox(height: AppSpacing.xs),
+                    AppCard(
+                      padding: EdgeInsets.all(AppSpacing.md),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (final h in (order['statusHistory'] as List).reversed)
+                            Padding(
+                              padding: EdgeInsets.only(bottom: AppSpacing.sm),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                    children: [
+                                      AppBadge(
+                                        label: h['status']?.toString() ?? '-',
+                                        tone: _toneForStatus(h['status']?.toString()),
+                                      ),
+                                      SizedBox(width: AppSpacing.sm),
+                                      Expanded(
+                                        child: Text(
+                                          h['changedAt'] != null
+                                              ? _formatHistoryDate(h['changedAt'].toString())
+                                              : '-',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall!
+                                              .copyWith(color: AppColors.onSurfaceVariant),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  if (h['changedBy'] != null &&
+                                      h['changedBy']['name'] != null) ...[
+                                    SizedBox(height: 2),
+                                    Text(
+                                      'by ${h['changedBy']['name']}${h['changedBy']['accountType'] != null ? ' (${h['changedBy']['accountType']})' : ''}',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodySmall!
+                                          .copyWith(color: AppColors.onSurfaceVariant),
+                                    ),
+                                  ],
+                                  if (h['remarks'] != null &&
+                                      h['remarks'].toString().isNotEmpty) ...[
+                                    SizedBox(height: 2),
+                                    Text(
+                                      h['remarks'].toString(),
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodySmall!
+                                          .copyWith(fontStyle: FontStyle.italic),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
 
                   // --- SalesExecutive action: Entity + Warehouse + Branch + Narration ---
                   if (order['status'] == 'PENDING' &&
@@ -575,6 +666,42 @@ class _OrderDetailsScreenState extends State<OrderDetailsScreen> {
               ),
       ),
     );
+  }
+}
+
+Widget _itemImage(Map<String, dynamic> item) {
+  final url = (item['productOfferThumbnailUrl'] ?? item['productOfferImageUrl'])?.toString();
+  if (url != null && url.isNotEmpty) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Image.network(
+        url,
+        width: 44,
+        height: 44,
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) => _imagePlaceholder(),
+      ),
+    );
+  }
+  return _imagePlaceholder();
+}
+
+Widget _imagePlaceholder() => Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        color: AppColors.infoBg,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: const Icon(Icons.image_not_supported_outlined, size: 20, color: AppColors.onSurfaceVariant),
+    );
+
+String _formatHistoryDate(String iso) {
+  try {
+    final dt = DateTime.parse(iso).toLocal();
+    return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year} ${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
+  } catch (_) {
+    return iso;
   }
 }
 

--- a/lib/screens/myOrders/myOrdersPage.dart
+++ b/lib/screens/myOrders/myOrdersPage.dart
@@ -16,7 +16,7 @@ import '../../widgets/primitives/app_badge.dart';
 import '../../widgets/primitives/app_empty_state.dart';
 import '../../widgets/primitives/app_list_row.dart';
 
-const _kStatusOptions = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'IN-PARCEL'];
+const _kStatusOptions = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'PARTIALLY_DISPATCHED', 'MANUALLY_DISPATCHED'];
 const _kPageSize = 20;
 
 AppBadgeTone _toneForStatus(String? s) {
@@ -25,6 +25,8 @@ AppBadgeTone _toneForStatus(String? s) {
     case 'DELIVERED':
     case 'COMPLETED':
     case 'SUCCESS':
+    case 'DISPATCHED':
+    case 'MANUALLY_DISPATCHED':
       return AppBadgeTone.success;
     case 'FAILED':
     case 'CANCELLED':
@@ -35,6 +37,8 @@ AppBadgeTone _toneForStatus(String? s) {
     case 'IN_PROGRESS':
     case 'PROCESSING':
       return AppBadgeTone.info;
+    case 'PARTIALLY_DISPATCHED':
+      return AppBadgeTone.neutral;
     default:
       return AppBadgeTone.neutral;
   }
@@ -63,6 +67,35 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
   List<Map<String, dynamic>> dealers = [];
   String? dealersError;
 
+  // Sales executive filter — stores mobile number
+  String? salesExecutiveFilter;
+  List<Map<String, dynamic>> salesExecutives = [];
+  String? salesExecutivesError;
+
+  // Branch filter — stores iMasterId as string
+  String? branchFilter;
+  List<Map<String, dynamic>> branches = [];
+  String? branchesError;
+
+  // Filter drawer draft state (applied on confirm)
+  String? _draftStatus;
+  String? _draftDealerCode;
+  String? _draftSalesExecutive;
+  String? _draftBranch;
+  bool _showDealerResults = false;
+  bool _showSeResults = false;
+  bool _showBranchResults = false;
+  List<Map<String, dynamic>> _dealerResults = [];
+  List<Map<String, dynamic>> _seResults = [];
+  List<Map<String, dynamic>> _branchResults = [];
+  final _dealerController = TextEditingController();
+  final _seController = TextEditingController();
+  final _branchController = TextEditingController();
+  final _dealerFocusNode = FocusNode();
+  final _seFocusNode = FocusNode();
+  final _branchFocusNode = FocusNode();
+  final _filterPanelScrollController = ScrollController();
+
   int _fetchGeneration = 0;
   int _loadersOnStack = 0;
 
@@ -71,11 +104,24 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
   bool get _showFilters =>
       accountType == 'SuperUser' || accountType == 'SalesExecutive';
 
+  // Shown for SuperUser (all SEs) or Senior SE (their juniors + self, only when non-empty)
+  bool get _showSalesExecutiveFilter =>
+      accountType == 'SuperUser' || (accountType == 'SalesExecutive' && salesExecutives.isNotEmpty);
+
+  int get _activeFilterCount =>
+      (statusFilter != null ? 1 : 0) +
+      (dealerCodeFilter != null ? 1 : 0) +
+      (salesExecutiveFilter != null ? 1 : 0) +
+      (branchFilter != null ? 1 : 0);
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _scrollController.addListener(_scrollListener);
+    _dealerFocusNode.addListener(_onDealerFocusChange);
+    _seFocusNode.addListener(_onSeFocusChange);
+    _branchFocusNode.addListener(_onBranchFocusChange);
     _bootstrap();
   }
 
@@ -86,6 +132,12 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
     accountType = auth.userAccountType ?? '';
     if (_showFilters) {
       _loadDealers();
+      _loadBranches();
+    }
+    if (accountType == 'SuperUser') {
+      _loadSalesExecutives();
+    } else if (accountType == 'SalesExecutive') {
+      _loadJuniorSalesExecutives(auth);
     }
     await _fetchPage();
   }
@@ -104,6 +156,13 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
     _loadersOnStack = 0;
     WidgetsBinding.instance.removeObserver(this);
     _scrollController.dispose();
+    _dealerController.dispose();
+    _seController.dispose();
+    _branchController.dispose();
+    _dealerFocusNode.dispose();
+    _seFocusNode.dispose();
+    _branchFocusNode.dispose();
+    _filterPanelScrollController.dispose();
     super.dispose();
   }
 
@@ -140,10 +199,91 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
     }
   }
 
+  Future<void> _loadSalesExecutives() async {
+    try {
+      final response = await http.get(
+        Uri.parse(BASE_URL + GET_SALES_EXECUTIVES),
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": accesstoken!,
+        },
+      );
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final list = (data['data'] as List?) ?? [];
+        if (mounted) {
+          setState(() {
+            salesExecutives = list.cast<Map<String, dynamic>>();
+            salesExecutivesError = null;
+          });
+        }
+      } else {
+        if (mounted) setState(() => salesExecutivesError = 'Could not load sales executives');
+      }
+    } catch (_) {
+      if (mounted) setState(() => salesExecutivesError = 'Could not load sales executives');
+    }
+  }
+
+  Future<void> _loadJuniorSalesExecutives(AuthProvider auth) async {
+    try {
+      final response = await http.get(
+        Uri.parse(BASE_URL + GET_JUNIOR_SALES_EXECUTIVES),
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": accesstoken!,
+        },
+      );
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final juniors = ((data['data'] as List?) ?? []).cast<Map<String, dynamic>>();
+        if (juniors.isNotEmpty && mounted) {
+          // Prepend self so the Senior SE can filter to only their own orders
+          final self = <String, dynamic>{
+            'name': '${auth.userFullName ?? 'Me'} (Me)',
+            'mobile': auth.userMobileNumber ?? '',
+          };
+          setState(() {
+            salesExecutives = [self, ...juniors];
+            salesExecutivesError = null;
+          });
+        }
+      } else {
+        if (mounted) setState(() => salesExecutivesError = 'Could not load junior sales executives');
+      }
+    } catch (_) {
+      if (mounted) setState(() => salesExecutivesError = 'Could not load junior sales executives');
+    }
+  }
+
+  Future<void> _loadBranches() async {
+    try {
+      final response = await http.get(
+        Uri.parse(BASE_URL + GET_FOCUS_BRANCHES),
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": accesstoken!,
+        },
+      );
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final list = (data['branches'] as List?) ?? [];
+        if (mounted) {
+          setState(() {
+            branches = list.cast<Map<String, dynamic>>();
+            branchesError = null;
+          });
+        }
+      } else {
+        if (mounted) setState(() => branchesError = 'Could not load branches');
+      }
+    } catch (_) {
+      if (mounted) setState(() => branchesError = 'Could not load branches');
+    }
+  }
+
   Future<void> _resetAndReload() async {
     if (!mounted) return;
-    // Pop any in-flight loader the stale fetch pushed; that fetch will discard
-    // its response on the generation check and won't try to pop again.
     while (_loadersOnStack > 0 && mounted) {
       Navigator.pop(context);
       _loadersOnStack--;
@@ -152,7 +292,7 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
       myOrdersList.clear();
       currentPage = 1;
       hasMore = true;
-      isLoading = false; // abandon any in-flight fetch's local state guard
+      isLoading = false;
     });
     _fetchGeneration++;
     await _fetchPage();
@@ -181,6 +321,12 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
       if (dealerCodeFilter != null && dealerCodeFilter!.isNotEmpty) {
         body['dealerCode'] = dealerCodeFilter;
       }
+      if (salesExecutiveFilter != null && salesExecutiveFilter!.isNotEmpty) {
+        body['salesExecutiveMobile'] = salesExecutiveFilter;
+      }
+      if (branchFilter != null && branchFilter!.isNotEmpty) {
+        body['branchId'] = int.tryParse(branchFilter!) ?? branchFilter;
+      }
 
       final response = await http.post(
         Uri.parse(BASE_URL + GET_CART_ORDERS_LIST),
@@ -191,7 +337,6 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
         body: json.encode(body),
       );
 
-      // Stale fetch — discard so we don't write into the post-reset state.
       if (myGen != _fetchGeneration) return;
 
       if (response.statusCode == 200) {
@@ -226,7 +371,6 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
       if (mounted && myGen == _fetchGeneration) {
         setState(() => isLoading = false);
       }
-      // Only pop the loader if THIS fetch still owns it.
       if (loaderShown && mounted && myGen == _fetchGeneration && _loadersOnStack > 0) {
         Navigator.pop(context);
         _loadersOnStack--;
@@ -234,22 +378,134 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
     }
   }
 
-  void _onStatusChanged(String? value) {
-    setState(() => statusFilter = (value == null || value.isEmpty) ? null : value);
-    _resetAndReload();
-  }
-
-  void _onDealerChanged(String? code) {
-    setState(() => dealerCodeFilter = (code == null || code.isEmpty) ? null : code);
-    _resetAndReload();
-  }
-
-  void _clearFilters() {
-    if (statusFilter == null && dealerCodeFilter == null) return;
-    setState(() {
-      statusFilter = null;
-      dealerCodeFilter = null;
+  // Focus listeners — use addPostFrameCallback on blur to avoid fighting field switches.
+  void _scrollPanelToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _filterPanelScrollController.hasClients) {
+        _filterPanelScrollController.animateTo(
+          _filterPanelScrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOut,
+        );
+      }
     });
+  }
+
+  void _onDealerFocusChange() {
+    if (_dealerFocusNode.hasFocus) {
+      setState(() {
+        _dealerResults = _filterDealerList(_dealerController.text.trim().toLowerCase());
+        _showDealerResults = true;
+        _showSeResults = false;
+        _showBranchResults = false;
+      });
+      _scrollPanelToBottom();
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && !_dealerFocusNode.hasFocus) {
+          setState(() => _showDealerResults = false);
+        }
+      });
+    }
+  }
+
+  void _onSeFocusChange() {
+    if (_seFocusNode.hasFocus) {
+      setState(() {
+        _seResults = _filterSeList(_seController.text.trim().toLowerCase());
+        _showSeResults = true;
+        _showDealerResults = false;
+        _showBranchResults = false;
+      });
+      _scrollPanelToBottom();
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && !_seFocusNode.hasFocus) {
+          setState(() => _showSeResults = false);
+        }
+      });
+    }
+  }
+
+  void _onBranchFocusChange() {
+    if (_branchFocusNode.hasFocus) {
+      setState(() {
+        _branchResults = _filterBranchList(_branchController.text.trim().toLowerCase());
+        _showBranchResults = true;
+        _showDealerResults = false;
+        _showSeResults = false;
+      });
+      _scrollPanelToBottom();
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && !_branchFocusNode.hasFocus) {
+          setState(() => _showBranchResults = false);
+        }
+      });
+    }
+  }
+
+  List<Map<String, dynamic>> _filterDealerList(String term) {
+    if (term.isEmpty) return dealers.take(20).toList();
+    return dealers.where((d) {
+      final code = (d['dealerCode'] ?? '').toString().toLowerCase();
+      final name = (d['name'] ?? '').toString().toLowerCase();
+      return code.contains(term) || name.contains(term);
+    }).take(20).toList();
+  }
+
+  List<Map<String, dynamic>> _filterSeList(String term) {
+    if (term.isEmpty) return salesExecutives.take(20).toList();
+    return salesExecutives.where((se) {
+      final name = (se['name'] ?? '').toString().toLowerCase();
+      final mobile = (se['mobile'] ?? '').toString().toLowerCase();
+      return name.contains(term) || mobile.contains(term);
+    }).take(20).toList();
+  }
+
+  List<Map<String, dynamic>> _filterBranchList(String term) {
+    if (term.isEmpty) return branches.take(20).toList();
+    return branches.where((b) {
+      final id = (b['iMasterId'] ?? '').toString().toLowerCase();
+      final name = (b['sName'] ?? '').toString().toLowerCase();
+      return id.contains(term) || name.contains(term);
+    }).take(20).toList();
+  }
+
+  void _openFilterPanel() {
+    _draftStatus = statusFilter;
+    _draftDealerCode = dealerCodeFilter;
+    _draftSalesExecutive = salesExecutiveFilter;
+    _draftBranch = branchFilter;
+    _dealerController.text = _draftDealerCode == null ? '' : _labelForDealerCode(_draftDealerCode!);
+    _seController.text = _draftSalesExecutive == null ? '' : _labelForSalesExecutiveMobile(_draftSalesExecutive!);
+    _branchController.text = _draftBranch == null ? '' : _labelForBranch(_draftBranch!);
+    _showDealerResults = false;
+    _showSeResults = false;
+    _showBranchResults = false;
+    _scaffoldKey.currentState!.openEndDrawer();
+  }
+
+  void _closeFilterPanel() {
+    _dealerFocusNode.unfocus();
+    _seFocusNode.unfocus();
+    _branchFocusNode.unfocus();
+    if (mounted) {
+      setState(() {
+        _showDealerResults = false;
+        _showSeResults = false;
+        _showBranchResults = false;
+      });
+    }
+    if (mounted && Navigator.canPop(context)) Navigator.pop(context);
+  }
+
+  void _applyFilters() {
+    statusFilter = _draftStatus;
+    dealerCodeFilter = _draftDealerCode;
+    salesExecutiveFilter = _draftSalesExecutive;
+    branchFilter = _draftBranch;
+    _closeFilterPanel();
     _resetAndReload();
   }
 
@@ -262,115 +518,385 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
     return '${match['dealerCode']} — ${match['name'] ?? ''}';
   }
 
-  Widget _buildDealerPicker() {
-    // Searchable Autocomplete (pattern reused from PainterPopUpPage.dart).
-    final selectedLabel = dealerCodeFilter == null
-        ? ''
-        : (() {
-            final match = dealers.firstWhere(
-              (d) => d['dealerCode']?.toString() == dealerCodeFilter,
-              orElse: () => <String, dynamic>{},
-            );
-            if (match.isEmpty) return dealerCodeFilter!;
-            return '${match['dealerCode']} — ${match['name'] ?? ''}';
-          })();
+  String _labelForSalesExecutiveMobile(String mobile) {
+    final match = salesExecutives.firstWhere(
+      (se) => se['mobile']?.toString() == mobile,
+      orElse: () => <String, dynamic>{},
+    );
+    if (match.isEmpty) return mobile;
+    return '${match['name'] ?? mobile} — $mobile';
+  }
 
-    return Autocomplete<Map<String, dynamic>>(
-      key: ValueKey('dealer-${dealerCodeFilter ?? "all"}'),
-      initialValue: TextEditingValue(text: selectedLabel),
-      displayStringForOption: (d) =>
-          '${d['dealerCode']} — ${d['name'] ?? ''}',
-      optionsBuilder: (TextEditingValue value) {
-        final term = value.text.trim().toLowerCase();
-        if (term.isEmpty) return dealers;
-        return dealers.where((d) {
-          final code = (d['dealerCode'] ?? '').toString().toLowerCase();
-          final name = (d['name'] ?? '').toString().toLowerCase();
-          return code.contains(term) || name.contains(term);
-        }).take(20);
-      },
-      fieldViewBuilder: (ctx, controller, focus, onSubmit) {
-        return TextField(
-          controller: controller,
-          focusNode: focus,
-          decoration: InputDecoration(
-            labelText: 'Dealer',
-            border: const OutlineInputBorder(),
-            isDense: true,
-            suffixIcon: (controller.text.isEmpty)
-                ? null
-                : IconButton(
-                    icon: const Icon(Icons.clear, size: 18),
-                    onPressed: () {
-                      controller.clear();
-                      _onDealerChanged(null);
-                    },
-                  ),
+  String _labelForBranch(String id) {
+    final match = branches.firstWhere(
+      (b) => b['iMasterId']?.toString() == id,
+      orElse: () => <String, dynamic>{},
+    );
+    if (match.isEmpty) return id;
+    return '${match['iMasterId']} — ${match['sName'] ?? ''}';
+  }
+
+  Widget _buildResultsList({
+    required List<Map<String, dynamic>> items,
+    required String Function(Map<String, dynamic>) labelFor,
+    required void Function(Map<String, dynamic>) onSelect,
+  }) {
+    return Container(
+      constraints: const BoxConstraints(maxHeight: 180),
+      margin: const EdgeInsets.only(top: 4),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: Colors.grey.shade300),
+        borderRadius: BorderRadius.circular(8),
+        boxShadow: const [BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, 2))],
+      ),
+      child: ListView.builder(
+        shrinkWrap: true,
+        padding: EdgeInsets.zero,
+        itemCount: items.length,
+        itemBuilder: (_, i) => InkWell(
+          onTap: () => setState(() => onSelect(items[i])),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
+            child: Text(labelFor(items[i])),
           ),
-          onChanged: (value) {
-            if (dealerCodeFilter == null) return;
-            if (value == _labelForDealerCode(dealerCodeFilter!)) return;
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (!mounted) return;
-              // Re-check after frame; user may have selected meanwhile.
-              if (dealerCodeFilter != null &&
-                  controller.text != _labelForDealerCode(dealerCodeFilter!)) {
-                _onDealerChanged(null);
-              }
-            });
-          },
-        );
-      },
-      onSelected: (d) => _onDealerChanged(d['dealerCode']?.toString()),
+        ),
+      ),
     );
   }
 
-  Widget _buildFilterBar() {
-    return Padding(
-      padding: EdgeInsets.fromLTRB(
-        AppSpacing.md, AppSpacing.sm, AppSpacing.md, AppSpacing.sm,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: DropdownButtonFormField<String?>(
-                  value: statusFilter,
-                  isExpanded: true,
-                  decoration: const InputDecoration(
-                    labelText: 'Status',
-                    border: OutlineInputBorder(),
-                    isDense: true,
+  Widget _buildFilterDrawer() {
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final bottomPadding = MediaQuery.of(context).padding.bottom;
+
+    return Drawer(
+      child: SafeArea(
+        bottom: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Header
+            Padding(
+              padding: EdgeInsets.fromLTRB(AppSpacing.md, AppSpacing.md, AppSpacing.sm, AppSpacing.xs),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text('Filters', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                  TextButton(
+                    onPressed: () => setState(() {
+                      _draftStatus = null;
+                      _draftDealerCode = null;
+                      _draftSalesExecutive = null;
+                      _draftBranch = null;
+                      _dealerController.clear();
+                      _seController.clear();
+                      _branchController.clear();
+                      _showDealerResults = false;
+                      _showSeResults = false;
+                      _showBranchResults = false;
+                    }),
+                    child: const Text('Clear all'),
                   ),
-                  items: [
-                    const DropdownMenuItem<String?>(value: null, child: Text('All')),
-                    ..._kStatusOptions.map(
-                      (s) => DropdownMenuItem<String?>(value: s, child: Text(s)),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+
+            // Scrollable filter fields
+            Expanded(
+              child: SingleChildScrollView(
+                controller: _filterPanelScrollController,
+                padding: EdgeInsets.fromLTRB(
+                  AppSpacing.md, AppSpacing.md, AppSpacing.md,
+                  AppSpacing.md + bottomInset,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Status
+                    DropdownButtonFormField<String?>(
+                      value: _draftStatus,
+                      isExpanded: true,
+                      decoration: const InputDecoration(
+                        labelText: 'Status',
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                      ),
+                      items: [
+                        const DropdownMenuItem<String?>(value: null, child: Text('All')),
+                        ..._kStatusOptions.map((s) => DropdownMenuItem<String?>(value: s, child: Text(s))),
+                      ],
+                      onChanged: (v) => setState(() => _draftStatus = v),
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Dealer search
+                    TapRegion(
+                      onTapOutside: (_) => _dealerFocusNode.unfocus(),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          TextField(
+                            controller: _dealerController,
+                            focusNode: _dealerFocusNode,
+                            decoration: InputDecoration(
+                              labelText: 'Dealer',
+                              hintText: 'Search by code or name',
+                              border: const OutlineInputBorder(),
+                              isDense: true,
+                              suffixIcon: _dealerController.text.isNotEmpty
+                                  ? IconButton(
+                                      icon: const Icon(Icons.clear, size: 18),
+                                      onPressed: () => setState(() {
+                                        _dealerController.clear();
+                                        _draftDealerCode = null;
+                                        _dealerResults = _filterDealerList('');
+                                        _showDealerResults = true;
+                                      }),
+                                    )
+                                  : null,
+                            ),
+                            onChanged: (val) => setState(() {
+                              _draftDealerCode = null;
+                              _dealerResults = _filterDealerList(val.trim().toLowerCase());
+                              _showDealerResults = true;
+                            }),
+                          ),
+                          if (_showDealerResults && _dealerResults.isNotEmpty)
+                            _buildResultsList(
+                              items: _dealerResults,
+                              labelFor: (d) => '${d['dealerCode']} — ${d['name'] ?? ''}',
+                              onSelect: (d) {
+                                _draftDealerCode = d['dealerCode']?.toString();
+                                _dealerController.text = _labelForDealerCode(_draftDealerCode!);
+                                _dealerFocusNode.unfocus();
+                              },
+                            ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Sales Executive search
+                    if (_showSalesExecutiveFilter) ...[
+                      TapRegion(
+                        onTapOutside: (_) => _seFocusNode.unfocus(),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            TextField(
+                              controller: _seController,
+                              focusNode: _seFocusNode,
+                              decoration: InputDecoration(
+                                labelText: 'Sales Executive',
+                                hintText: 'Search by name or mobile',
+                                border: const OutlineInputBorder(),
+                                isDense: true,
+                                suffixIcon: _seController.text.isNotEmpty
+                                    ? IconButton(
+                                        icon: const Icon(Icons.clear, size: 18),
+                                        onPressed: () => setState(() {
+                                          _seController.clear();
+                                          _draftSalesExecutive = null;
+                                          _seResults = _filterSeList('');
+                                          _showSeResults = true;
+                                        }),
+                                      )
+                                    : null,
+                              ),
+                              onChanged: (val) => setState(() {
+                                _draftSalesExecutive = null;
+                                _seResults = _filterSeList(val.trim().toLowerCase());
+                                _showSeResults = true;
+                              }),
+                            ),
+                            if (_showSeResults && _seResults.isNotEmpty)
+                              _buildResultsList(
+                                items: _seResults,
+                                labelFor: (se) => '${se['name'] ?? ''} — ${se['mobile'] ?? ''}',
+                                onSelect: (se) {
+                                  _draftSalesExecutive = se['mobile']?.toString();
+                                  _seController.text = _labelForSalesExecutiveMobile(_draftSalesExecutive!);
+                                  _seFocusNode.unfocus();
+                                },
+                              ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+
+                    // Branch search
+                    TapRegion(
+                      onTapOutside: (_) => _branchFocusNode.unfocus(),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          TextField(
+                            controller: _branchController,
+                            focusNode: _branchFocusNode,
+                            decoration: InputDecoration(
+                              labelText: 'Branch',
+                              hintText: 'Search by ID or name',
+                              border: const OutlineInputBorder(),
+                              isDense: true,
+                              suffixIcon: _branchController.text.isNotEmpty
+                                  ? IconButton(
+                                      icon: const Icon(Icons.clear, size: 18),
+                                      onPressed: () => setState(() {
+                                        _branchController.clear();
+                                        _draftBranch = null;
+                                        _branchResults = _filterBranchList('');
+                                        _showBranchResults = true;
+                                      }),
+                                    )
+                                  : null,
+                            ),
+                            onChanged: (val) => setState(() {
+                              _draftBranch = null;
+                              _branchResults = _filterBranchList(val.trim().toLowerCase());
+                              _showBranchResults = true;
+                            }),
+                          ),
+                          if (_showBranchResults && _branchResults.isNotEmpty)
+                            _buildResultsList(
+                              items: _branchResults,
+                              labelFor: (b) => '${b['iMasterId']} — ${b['sName'] ?? ''}',
+                              onSelect: (b) {
+                                _draftBranch = b['iMasterId']?.toString();
+                                _branchController.text = _labelForBranch(_draftBranch!);
+                                _branchFocusNode.unfocus();
+                              },
+                            ),
+                        ],
+                      ),
                     ),
                   ],
-                  onChanged: _onStatusChanged,
                 ),
               ),
-              const SizedBox(width: 8),
-              Expanded(child: _buildDealerPicker()),
-            ],
-          ),
-          if (dealersError != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: Text(dealersError!, style: const TextStyle(fontSize: 12, color: Colors.grey)),
             ),
-          if (statusFilter != null || dealerCodeFilter != null)
-            Align(
-              alignment: Alignment.centerRight,
-              child: TextButton(
-                onPressed: _clearFilters,
-                child: const Text('Clear filters'),
+
+            // Footer actions — pinned above keyboard / home indicator
+            const Divider(height: 1),
+            Padding(
+              padding: EdgeInsets.fromLTRB(
+                AppSpacing.md, AppSpacing.sm, AppSpacing.md,
+                AppSpacing.sm + bottomPadding,
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: _closeFilterPanel,
+                      child: const Text('Cancel'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _applyFilters,
+                      child: const Text('Apply'),
+                    ),
+                  ),
+                ],
               ),
             ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFiltersButton() {
+    final count = _activeFilterCount;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(AppSpacing.md, AppSpacing.sm, AppSpacing.md, 0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          Stack(
+            clipBehavior: Clip.none,
+            children: [
+              OutlinedButton.icon(
+                onPressed: _openFilterPanel,
+                icon: const Icon(Icons.tune, size: 18),
+                label: const Text('Filters'),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                ),
+              ),
+              if (count > 0)
+                Positioned(
+                  top: -6,
+                  right: -6,
+                  child: Container(
+                    width: 18,
+                    height: 18,
+                    decoration: const BoxDecoration(
+                      color: Colors.red,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(
+                      child: Text(
+                        '$count',
+                        style: const TextStyle(color: Colors.white, fontSize: 11, fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildOrderListBody() {
+    if (myOrdersList.isEmpty && !isLoading) {
+      return AppEmptyState(
+        icon: Icons.receipt_long_outlined,
+        title: 'No orders yet',
+        message: 'Your orders will appear here.',
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: () async => _resetAndReload(),
+      child: ListView.builder(
+        controller: _scrollController,
+        padding: EdgeInsets.all(AppSpacing.md),
+        itemCount: myOrdersList.length + (hasMore ? 1 : 0),
+        itemBuilder: (context, i) {
+          if (i >= myOrdersList.length) {
+            return const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+            );
+          }
+          final order = myOrdersList[i];
+          final orderId = order['orderId']?.toString() ?? '-';
+          final status = (order['status'] ?? 'PENDING').toString().toUpperCase();
+          final total = order['totalPrice']?.toString() ?? '-';
+          final createdAt = order['createdAt'] != null
+              ? Utils.formatDate(order['createdAt']).split(' ')[0]
+              : '-';
+          return Padding(
+            padding: EdgeInsets.only(bottom: AppSpacing.sm),
+            child: AppListRow(
+              title: 'Order #$orderId',
+              subtitle: '₹ $total · $createdAt',
+              trailing: AppBadge(label: status, tone: _toneForStatus(status)),
+              onTap: () async {
+                final result = await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => OrderDetailsScreen(order: order),
+                  ),
+                );
+                if (result == true) _resetAndReload();
+              },
+            ),
+          );
+        },
       ),
     );
   }
@@ -380,57 +906,12 @@ class _MyOrdersPageState extends State<MyOrdersPage> with WidgetsBindingObserver
     return Scaffold(
       key: _scaffoldKey,
       backgroundColor: AppColors.surface,
+      resizeToAvoidBottomInset: false,
+      endDrawer: _showFilters ? _buildFilterDrawer() : null,
       body: Column(
         children: [
-          if (_showFilters) _buildFilterBar(),
-          Expanded(
-            child: myOrdersList.isEmpty && !isLoading
-                ? AppEmptyState(
-                    icon: Icons.receipt_long_outlined,
-                    title: 'No orders yet',
-                    message: 'Your orders will appear here.',
-                  )
-                : RefreshIndicator(
-                    onRefresh: () async => _resetAndReload(),
-                    child: ListView.builder(
-                      controller: _scrollController,
-                      padding: EdgeInsets.all(AppSpacing.md),
-                      itemCount: myOrdersList.length + (hasMore ? 1 : 0),
-                      itemBuilder: (context, i) {
-                        if (i >= myOrdersList.length) {
-                          return Padding(
-                            padding: const EdgeInsets.all(16),
-                            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-                          );
-                        }
-                        final order = myOrdersList[i];
-                        final orderId = order['orderId']?.toString() ?? '-';
-                        final status = (order['status'] ?? 'PENDING').toString().toUpperCase();
-                        final total = order['totalPrice']?.toString() ?? '-';
-                        final createdAt = order['createdAt'] != null
-                            ? Utils.formatDate(order['createdAt']).split(' ')[0]
-                            : '-';
-                        return Padding(
-                          padding: EdgeInsets.only(bottom: AppSpacing.sm),
-                          child: AppListRow(
-                            title: 'Order #$orderId',
-                            subtitle: '₹ $total · $createdAt',
-                            trailing: AppBadge(label: status, tone: _toneForStatus(status)),
-                            onTap: () async {
-                              final result = await Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (_) => OrderDetailsScreen(order: order),
-                                ),
-                              );
-                              if (result == true) _resetAndReload();
-                            },
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-          ),
+          if (_showFilters) _buildFiltersButton(),
+          Expanded(child: _buildOrderListBody()),
         ],
       ),
     );

--- a/lib/screens/orders/ordersList/OrdersList.dart
+++ b/lib/screens/orders/ordersList/OrdersList.dart
@@ -21,6 +21,8 @@ AppBadgeTone _toneForStatus(String? s) {
     case 'DELIVERED':
     case 'COMPLETED':
     case 'SUCCESS':
+    case 'DISPATCHED':
+    case 'MANUALLY_DISPATCHED':
       return AppBadgeTone.success;
     case 'FAILED':
     case 'CANCELLED':
@@ -31,6 +33,8 @@ AppBadgeTone _toneForStatus(String? s) {
     case 'IN_PROGRESS':
     case 'PROCESSING':
       return AppBadgeTone.info;
+    case 'PARTIALLY_DISPATCHED':
+      return AppBadgeTone.neutral;
     default:
       return AppBadgeTone.neutral;
   }

--- a/lib/screens/pointsLedger/pointsLedgerPage.dart
+++ b/lib/screens/pointsLedger/pointsLedgerPage.dart
@@ -38,6 +38,8 @@ class _PointsLedgerPageState extends State<PointsLedgerPage> {
 
   TextEditingController searchController = TextEditingController();
   DateTime? selectedDate;
+  // null = All, 'pending' = credit note not issued, 'issued' = credit note issued
+  String? creditNoteStatusFilter;
 
   @override
   void initState() {
@@ -81,6 +83,8 @@ class _PointsLedgerPageState extends State<PointsLedgerPage> {
             ? int.tryParse(searchController.text)
             : null,
         "date": selectedDate != null ? _dateFormat.format(selectedDate!) : null,
+        if (creditNoteStatusFilter != null)
+          "creditNoteStatus": creditNoteStatusFilter,
       };
 
       final response = await http.post(
@@ -103,6 +107,7 @@ class _PointsLedgerPageState extends State<PointsLedgerPage> {
               if (currentPage == 1 &&
                   searchController.text.isEmpty &&
                   selectedDate == null &&
+                  creditNoteStatusFilter == null &&
                   newData.isNotEmpty) {
                 final raw = newData.first['pointsBalance'];
                 _currentBalance = raw is num
@@ -170,11 +175,46 @@ class _PointsLedgerPageState extends State<PointsLedgerPage> {
     setState(() {
       searchController.clear();
       selectedDate = null;
+      creditNoteStatusFilter = null;
       currentPage = 1;
       myPointLedgerList.clear();
       hasMore = true;
     });
     getPointsLedgerList();
+  }
+
+  Widget _statusChip(String label, String? value) {
+    final selected = creditNoteStatusFilter == value;
+    return GestureDetector(
+      onTap: () {
+        if (selected) return;
+        setState(() {
+          creditNoteStatusFilter = value;
+          currentPage = 1;
+          myPointLedgerList.clear();
+          hasMore = true;
+        });
+        getPointsLedgerList();
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : AppColors.outline,
+          borderRadius: AppRadius.rPill,
+          border: Border.all(
+            color: selected ? AppColors.primary : AppColors.outlineVariant,
+          ),
+        ),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                color: selected ? Colors.white : AppColors.onSurface,
+                fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+              ),
+        ),
+      ),
+    );
   }
 
   @override
@@ -282,6 +322,21 @@ class _PointsLedgerPageState extends State<PointsLedgerPage> {
                   ),
                 ),
               ),
+            ],
+          ),
+        ),
+
+        // ── Credit note status chips ──────────────────────────────────────
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+              AppSpacing.md, 0, AppSpacing.md, AppSpacing.sm),
+          child: Row(
+            children: [
+              _statusChip('All', null),
+              const SizedBox(width: AppSpacing.sm),
+              _statusChip('Pending', 'pending'),
+              const SizedBox(width: AppSpacing.sm),
+              _statusChip('Issued', 'issued'),
             ],
           ),
         ),

--- a/lib/services/config.dart
+++ b/lib/services/config.dart
@@ -62,6 +62,10 @@ const GET_CART_ORDERS_LIST = "order/orders";
 
 const GET_ORDER_DEALERS = "order/dealers";
 
+const GET_SALES_EXECUTIVES = "users/sales-executives";
+
+const GET_JUNIOR_SALES_EXECUTIVES = "users/junior-sales-executives";
+
 const CREATE_CHECKOUT = "/order/create"; //checkout
 
 const GET_MY_PAINTERS = "users/getMyPainters";

--- a/lib/services/config.dart
+++ b/lib/services/config.dart
@@ -53,6 +53,7 @@ const POST_SCANNED_DATA = "transaction/redeemPoints"; //new api with POST
 
 // const GET_PRODUCT_OFFERS = "productOffers/getProductOffers";
 const GET_PRODUCT_OFFERS = "productOffers/searchProductOffers";
+const GET_ACTIVE_DEALS = "deals/active";
 const GET_CATALOG_SEARCH = "productCatlog/search"; //new api for catalog
 
 const UPDATE_ORDER_STATUS = "order/updateOrderStatus"; // update order status

--- a/lib/services/deals_service.dart
+++ b/lib/services/deals_service.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../model/deal.dart';
+import 'config.dart';
+
+class DealsService {
+  /// Fetch the list of currently-active deals for the logged-in user.
+  ///
+  /// The server resolves the dealer's category from the JWT and filters
+  /// server-side. We just pass the bearer token along.
+  ///
+  /// On success returns the parsed list (which can be empty). On error
+  /// (network drop, 4xx/5xx, malformed JSON) returns an empty list — the
+  /// caller treats this as "no deals to show" and skips the dialog. We
+  /// never want a flaky deals call to interrupt the post-login UX.
+  static Future<List<Deal>> fetchActiveDeals(String bearerToken) async {
+    try {
+      final response = await http
+          .get(
+            Uri.parse('$BASE_URL$GET_ACTIVE_DEALS'),
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': bearerToken,
+            },
+          )
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode != 200) return const [];
+      final body = json.decode(response.body);
+      if (body is! List) return const [];
+      return body
+          .whereType<Map<String, dynamic>>()
+          .map(Deal.fromJson)
+          .toList(growable: false);
+    } catch (_) {
+      return const [];
+    }
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,6 +10,7 @@ import file_selector_macos
 import flutter_secure_storage_macos
 import path_provider_foundation
 import shared_preferences_foundation
+import sqflite_darwin
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -18,5 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.9.3"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -286,6 +310,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_easyloading:
     dependency: "direct main"
     description:
@@ -672,6 +704,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -840,6 +880,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.2"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -941,6 +989,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.8"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -973,6 +1061,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1069,6 +1165,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.4"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:
@@ -1150,5 +1254,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.6"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 
 # version: 1.0.1+3
-version: 22.0.3+48
+version: 22.1.0+49
 
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   flutter_secure_storage: ^9.2.2
   google_fonts: ^6.2.1
+  cached_network_image: ^3.4.0
 
 
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- New `Deal` Dart model + `DealsService.fetchActiveDeals(token)` HTTP client.
- `ActiveDealsDialog` widget — full-screen swipeable PageView of CachedNetworkImage, page indicator dots, Close button. **No auto-advance** (user-paced — this is a login interrupt).
- `AuthProvider.justLoggedIn` transient flag, set on OTP success, consumed by `DashboardNewPage` to fetch + show the dialog after the first frame.
- Cache-busts deal image URLs with `?v=<updatedAt-ms>` so admin updates show up.
- Errors are silent (empty list returned) so a flaky network never blocks login.

## Files added
- `lib/model/deal.dart`
- `lib/services/deals_service.dart`
- `lib/screens/deals/ActiveDealsDialog.dart`

## Files modified
- `lib/services/config.dart` — added `GET_ACTIVE_DEALS = "deals/active"`
- `lib/providers/auth_provider.dart` — added `_justLoggedIn` flag, `markJustLoggedIn()`, `clearJustLoggedIn()`
- `lib/screens/authentication/otp/OtpPage.dart` — calls `authProvider.markJustLoggedIn()` before navigating to dashboard on OTP success
- `lib/screens/dashboard/DashboardNewPage.dart` — `_maybeShowActiveDealsAfterLogin()` in `initState` reads the flag, fetches active deals via the service, shows the dialog if non-empty
- `pubspec.yaml` / `pubspec.lock` — added `cached_network_image: ^3.4.0` (resolved 3.4.1)

## Backend dependency
Depends on the backend PR `feat/deals-feature` on aultra-paints-backend (#156) which adds `GET /api/deals/active`. Merge the backend PR first.

## Test plan
- [x] `flutter analyze` — only 2 info-level lints on new files, both project-wide style conventions (file naming, super-params), no errors/warnings introduced
- [ ] Dealer with matching active deal → dialog appears after login
- [ ] Dealer with no matching deals → no dialog
- [ ] Swipe between deals → page indicator updates
- [ ] Tap on image → no-op
- [ ] Offline login → silent skip, dashboard loads normally
- [ ] Expired deal → not shown
- [ ] Inactive deal → not shown
- [ ] Deal targeting a category the user isn't in → not shown
- [ ] Multi-category dealer sees deals from each of their categories
- [ ] Hot-restart after dismissing dialog → does NOT re-show same deals (flag is cleared)
- [ ] Kill app + log in again → dialog re-appears (correct)

## Spec & Plan
- Spec: `docs/superpowers/specs/2026-05-18-deals-feature-design.md` (in parent `aultra_paints/` dir)
- Plan: `docs/superpowers/plans/2026-05-18-deals-feature.md` (same dir)

## Notes
- Branched on top of `feat/orders-list-filters`. Once that PR lands, rebase deals onto main.

Generated with [Claude Code](https://claude.com/claude-code)
